### PR TITLE
Make imap-to-local-html work on Windows

### DIFF
--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -104,7 +104,7 @@ def renderTemplate(templateFrom, saveTo, **kwargs):
     template = env.from_string(templateContents)
     result = template.render(**kwargs)
     if saveTo:
-        with open(saveTo, "w") as f:
+        with open(saveTo, "w", encoding="utf-8") as f:
             if server.get('prettify', True):
                 try:
                     soup = BeautifulSoup(result, "html.parser")

--- a/remote2local.py
+++ b/remote2local.py
@@ -101,7 +101,7 @@ def getMessageToLocalDir(mailFolder, mail, maildir_raw):
     print("Copying folder %s (%s)" % (normalize(mailFolder, "utf7"), len(messageList)), end="")
     for message_id in messageList:
         result, data = mail.fetch(message_id , "(RFC822)")
-        raw_email = data[0][1]
+        raw_email = data[0][1].replace(b'\r\n', b'\n')
         maildir_folder = mailFolder.replace("/", ".")
         saveToMaildir(raw_email, maildir_folder, maildir_raw)
         sofar += 1


### PR DESCRIPTION
imap-to-local-html is a cool tool, but I ran into problems using it on Windows. The two commits fixed the problem and should also work on Linux. 