### PR TITLE
Bug fix for iCloud IMAP not returning valid data

### DIFF
--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -336,22 +336,23 @@ def getMailFolders():
                 mailFolders[menu]["parent"] = ""
 
     # Add in any additional folders that may be mbox only
-    for i in server.get('folders'):
+    for folder in server.get('folders'):
         exists = False
-        for e in mailFolders:
-            if mailFolders[e].title == i:
+        for existing in mailFolders:
+            if mailFolders[existing].title == folder:
                 exists = True
+                break
 
         if exists = True:
             continue
 
         count += 1
 
-        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(i, "utf7"), defaultVal="folder"))
+        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(folder, "utf7"), defaultVal="folder"))
 
-        mailFolders[i] = {
-            "id": i,
-            "title": i,
+        mailFolders[folder] = {
+            "id": folder,
+            "title": folder,
             "parent": "",
             "selected": True,
             "file": fileName,

--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -337,6 +337,8 @@ def getMailFolders():
 
     # Add in any additional folders that may be mbox only
     for folderName in server.get('folders'):
+        folderName = normalize(folderName, "utf7")
+        
         exists = False
         for existingName in mailFolders:
             if mailFolders[existingName].title == folderName:
@@ -348,11 +350,11 @@ def getMailFolders():
 
         count += 1
 
-        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(folderName, "utf7"), defaultVal="folder"))
+        fileName = "%03d-%s.html" % (count, slugify_safe(folderName, defaultVal="folder"))
 
-        mailFolders[normalize(folderName, "utf8")] = {
-            "id": normalize(folderName, "utf8"),
-            "title": normalize(folderName, "utf8"),
+        mailFolders[folderName] = {
+            "id": folderName,
+            "title": folderName,
             "parent": "",
             "selected": True,
             "file": fileName,

--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -749,6 +749,34 @@ for folderID in allFolders:
             else:
                 print("Connection gave more than 5 errors. Not trying again")
 
+    print(("Getting messages from mbox from file: %s.") % normalize(folderID, "utf7"))
+    try:
+        mbox_file = mailbox.mbox("%s/%s" % (maildir, normalize(folderID, "utf7")), create=False)
+        
+        mbox = mailbox.Maildir(maildir_raw, factory=mailbox.MaildirMessage, create=True)
+        folder = mbox.add_folder(folderID.replace("/", "."))    
+        folder.lock()
+        
+        for msg in mbox_file:
+            try:
+                message_key = folder.add(msg)
+                folder.flush()
+
+                maildir_message = folder.get_message(message_key)
+                try:
+                    message_date_epoch = time.mktime(parsedate(decode_header(maildir_message.get("Date"))[0][0]))
+                except TypeError as typeerror:
+                    message_date_epoch = time.mktime((2000, 1, 1, 1, 1, 1, 1, 1, 0))
+                maildir_message.set_date(message_date_epoch)
+                maildir_message.add_flag("s")
+
+        mbox_file.close()
+        
+    finally:
+        folder.unlock()
+        folder.close()
+        mbox.close()
+
     print(("Done with folder: %s.") % normalize(folderID, "utf7"))
 
 renderIndexPage()

--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -350,9 +350,9 @@ def getMailFolders():
 
         fileName = "%03d-%s.html" % (count, slugify_safe(normalize(folderName, "utf7"), defaultVal="folder"))
 
-        mailFolders[folderName] = {
-            "id": folderName,
-            "title": folderName,
+        mailFolders[normalize(folderName, "utf8")] = {
+            "id": normalize(folderName, "utf8"),
+            "title": normalize(folderName, "utf8"),
             "parent": "",
             "selected": True,
             "file": fileName,

--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -336,10 +336,10 @@ def getMailFolders():
                 mailFolders[menu]["parent"] = ""
 
     # Add in any additional folders that may be mbox only
-    for folder in server.get('folders'):
+    for folderName in server.get('folders'):
         exists = False
-        for existing in mailFolders:
-            if mailFolders[existing].title == folder:
+        for existingName in mailFolders:
+            if mailFolders[existingName].title == folderName:
                 exists = True
                 break
 
@@ -348,11 +348,11 @@ def getMailFolders():
 
         count += 1
 
-        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(folder, "utf7"), defaultVal="folder"))
+        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(folderName, "utf7"), defaultVal="folder"))
 
-        mailFolders[folder] = {
-            "id": folder,
-            "title": folder,
+        mailFolders[folderName] = {
+            "id": folderName,
+            "title": folderName,
             "parent": "",
             "selected": True,
             "file": fileName,

--- a/imap-to-local-html.py
+++ b/imap-to-local-html.py
@@ -335,6 +335,29 @@ def getMailFolders():
             if mailFolders[menu]["parent"] == menusWithNoParent[0]:
                 mailFolders[menu]["parent"] = ""
 
+    # Add in any additional folders that may be mbox only
+    for i in server.get('folders'):
+        exists = False
+        for e in mailFolders:
+            if mailFolders[e].title == i:
+                exists = True
+
+        if exists = True:
+            continue
+
+        count += 1
+
+        fileName = "%03d-%s.html" % (count, slugify_safe(normalize(i, "utf7"), defaultVal="folder"))
+
+        mailFolders[i] = {
+            "id": i,
+            "title": i,
+            "parent": "",
+            "selected": True,
+            "file": fileName,
+            "link": "/%s" % fileName,
+        }
+
     return mailFolders
 
 

--- a/remote2local.py
+++ b/remote2local.py
@@ -92,6 +92,10 @@ def getMessageToLocalDir(mailFolder, mail, maildir_raw):
 
     try:
         typ, mdata = mail.search(None, "ALL")
+        # could restrict run here with '(SINCE "01-Jan-2024")' or perhaps a yml param
+        if mdata[0] == None:
+            print("...No new files!")
+            return
     except Exception as imaperror:
         print("Error in IMAP Query: %s." % imaperror)
         print("Does the imap folder \"%s\" exists?" % mailFolder)

--- a/remote2local.py
+++ b/remote2local.py
@@ -102,6 +102,12 @@ def getMessageToLocalDir(mailFolder, mail, maildir_raw):
     for message_id in messageList:
         result, data = mail.fetch(message_id , "(RFC822)")
         raw_email = data[0][1]
+
+        # iCloud does not return RFC822 correctly and returns an int
+        if type(raw_email) == type(1):
+            result, data = mail.fetch(message_id, "(BODY[])")
+            raw_email = email.message_from_bytes(data[0][1])
+        
         maildir_folder = mailFolder.replace("/", ".")
         saveToMaildir(raw_email, maildir_folder, maildir_raw)
         sofar += 1

--- a/remote2local.py
+++ b/remote2local.py
@@ -2,6 +2,7 @@ from email.header import decode_header
 from email.utils import parsedate
 import imaplib
 import mailbox
+import email
 import re
 import sys
 import time

--- a/remote2local.py
+++ b/remote2local.py
@@ -112,7 +112,8 @@ def getMessageToLocalDir(mailFolder, mail, maildir_raw):
         if type(raw_email) == type(1):
             result, data = mail.fetch(message_id, "(BODY[])")
             raw_email = email.message_from_bytes(data[0][1])
-        
+            
+        raw_email = raw_email.replace(b'\r\n', b'\n')
         maildir_folder = mailFolder.replace("/", ".")
         saveToMaildir(raw_email, maildir_folder, maildir_raw)
         sofar += 1


### PR DESCRIPTION
Bug in iCloud’s IMAP returning an int not str when requesting the email, so instead request binary and parse